### PR TITLE
Fix length issues of abbreviation

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,5 @@
 package main
+
 import (
 	"fmt"
 	"os"
@@ -9,7 +10,6 @@ import (
 )
 
 // bug 1 // go run main.go 2023-04-22T09:49:59+09:00 JST
-// bug 2 // go run main.go 2023-04-21 15:49:42 PDT NZS
 
 func param(z int) string {
 
@@ -53,14 +53,19 @@ func param(z int) string {
 	y = strings.ReplaceAll(x, "PST", "UTC-8")
 	x = strings.ReplaceAll(y, "SGT", "UTC+8")
 
-	return x
+	// Check UTC, UTC+1, UTC+2, ... UTC+12, or UTC-1, UTC-2, .... UTC-11 //
+	ck, _ := regexp.MatchString(`UTC$|UTC[+-][1-9]`, x)
+	if ck == true {
+		return x
+	}
+	return "false"
 }
 
 func main() {
 
 	fmt.Printf("\n")
 
-	if (len(os.Args) == 3 && len(os.Args[2]) == 3) || (len(os.Args) == 3 && len(os.Args[2]) == 4) {
+	if len(os.Args) == 3 && len(os.Args[2]) >= 3 && len(os.Args[2]) <= 6 && param(2) != "false" {
 
 		// UTC-1, UTC, UTC+1, UTC+2,... -> -1, 0, 1, 2, ....
 		inc, _ := strconv.Atoi((strings.Trim(param(2), "UTC")))
@@ -110,8 +115,7 @@ func main() {
 
 	}
 
-
-	if len(os.Args) == 4 && len(os.Args[3]) >= 3 && len(os.Args[3]) <= 6 {
+	if len(os.Args) == 4 && len(os.Args[3]) >= 3 && len(os.Args[3]) <= 6 && param(3) != "false" {
 
 		// UTC-1, UTC, UTC+1, UTC+2,... -> -1, 0, 1, 2, ....
 		inc, _ := strconv.Atoi((strings.Trim(param(3), "UTC")))
@@ -148,12 +152,14 @@ func main() {
 			// test command 16 // go run main.go 2023/04/10 08:45 uTC-7
 			// test command 17 // go run main.go 2023/04/10 08:45:39 uTC-8
 			// test command 18 // go run main.go 2023/04/22 09:00 NZST
-			// test command 19 // go run main.go 2023/04/22 09:00 AWST
-			// test command 20 // go run main.go 2023/04/22 09:00 JST
-			// test command 21 // go run main.go 2023/04/22 09:00 HKT
-			// test command 22 // go run main.go 2023/04/22 09:00 SGT
-			// test command 23 // go run main.go 2023/04/22 09:00 PDt
-			// test command 24 // go run main.go 2023/04/22 09:00:00 pst
+			// test command 19 // go run main.go 2023/04/22 09:00 AEDT
+			// test command 20 // go run main.go 2023/04/22 09:00 AEST
+			// test command 21 // go run main.go 2023/04/22 09:00 AWST
+			// test command 22 // go run main.go 2023/04/22 09:00 JST
+			// test command 23 // go run main.go 2023/04/22 09:00 HKT
+			// test command 24 // go run main.go 2023/04/22 09:00 SGT
+			// test command 25 // go run main.go 2023/04/22 09:00 PDt
+			// test command 26 // go run main.go 2023/04/22 09:00:00 pst
 
 			year, _ := strconv.Atoi(arg1[0])
 			var m, _ = strconv.Atoi(arg1[1])
@@ -177,25 +183,27 @@ func main() {
 			}
 
 		} else if len(arg2) == 3 {
-			// test command 25 // go run main.go 2023-04-10 09:00 UTC-1
-			// test command 26 // go run main.go 2023-04-10 09:00 UTC
-			// test command 27 // go run main.go 2023-04-10 09:00 UTC+9
-			// test command 28 // go run main.go 2023-04-10 08:00 UTC-2
-			// test command 29 // go run main.go 2023-04-10 08:45 UTC-2
-			// test command 30 // go run main.go 2023-04-10 08:45:39 UTC-2
-			// test command 31 // go run main.go 2023-04-10 09:00 utc-5
-			// test command 32 // go run main.go 2023-04-10 09:00 utc
-			// test command 33 // go run main.go 2023-04-10 09:00 utc+9
-			// test command 34 // go run main.go 2023-04-10 08:00 uTC-6
-			// test command 35 // go run main.go 2023-04-10 08:45 uTC-7
-			// test command 36 // go run main.go 2023-04-10 08:45:39 uTC-8
-			// test command 37 // go run main.go 2023-04-22 09:00 NZST
-			// test command 38 // go run main.go 2023-04-22 09:00 AWST
-			// test command 39 // go run main.go 2023-04-22 09:00 JST
-			// test command 40 // go run main.go 2023-04-22 09:00 HKT
-			// test command 41 // go run main.go 2023-04-22 09:00 SGT
-			// test command 42 // go run main.go 2023-04-22 09:00 PDt
-			// test command 43 // go run main.go 2023-04-22 09:00:00 pst
+			// test command 27 // go run main.go 2023-04-10 09:00 UTC-1
+			// test command 28 // go run main.go 2023-04-10 09:00 UTC
+			// test command 29 // go run main.go 2023-04-10 09:00 UTC+9
+			// test command 30 // go run main.go 2023-04-10 08:00 UTC-2
+			// test command 31 // go run main.go 2023-04-10 08:45 UTC-2
+			// test command 32 // go run main.go 2023-04-10 08:45:39 UTC-2
+			// test command 33 // go run main.go 2023-04-10 09:00 utc-5
+			// test command 34 // go run main.go 2023-04-10 09:00 utc
+			// test command 35 // go run main.go 2023-04-10 09:00 utc+9
+			// test command 36 // go run main.go 2023-04-10 08:00 uTC-6
+			// test command 37 // go run main.go 2023-04-10 08:45 uTC-7
+			// test command 38 // go run main.go 2023-04-10 08:45:39 uTC-8
+			// test command 39 // go run main.go 2023-04-22 09:00 NZST
+			// test command 40 // go run main.go 2023-04-22 09:00 AEDT
+			// test command 41 // go run main.go 2023-04-22 09:00 AEST
+			// test command 42 // go run main.go 2023-04-22 09:00 AWST
+			// test command 43 // go run main.go 2023-04-22 09:00 JST
+			// test command 44 // go run main.go 2023-04-22 09:00 HKT
+			// test command 45 // go run main.go 2023-04-22 09:00 SGT
+			// test command 46 // go run main.go 2023-04-22 09:00 PDt
+			// test command 47 // go run main.go 2023-04-22 09:00:00 pst
 
 			year, _ := strconv.Atoi(arg2[0])
 			var m, _ = strconv.Atoi(arg2[1])
@@ -221,8 +229,7 @@ func main() {
 		}
 	}
 
-
-	if len(os.Args) == 5 && (len(os.Args[3]) >= 3 && len(os.Args[3]) <= 6) && (len(os.Args[4]) >= 3 && len(os.Args[4]) <= 6) {
+	if len(os.Args) == 5 && (len(os.Args[3]) >= 3 && len(os.Args[3]) <= 6 && param(3) != "false") && (len(os.Args[4]) >= 3 && len(os.Args[4]) <= 6 && param(4) != "false") {
 
 		// UTC-1, UTC, UTC+1, UTC+2,... -> -1, 0, 1, 2, ....
 		inc1, _ := strconv.Atoi((strings.Trim(param(3), "UTC")))
@@ -249,21 +256,21 @@ func main() {
 		s, _ := strconv.Atoi(arg3[2])
 
 		if len(arg1) == 3 {
-			// test command 44 // go run main.go 2023/04/09 00:00 UTC UTC+9
-			// test command 45 // go run main.go 2023/04/09 00:00 UTC+1 UTC+9
-			// test command 46 // go run main.go 2023/04/09 00:00 UTC+2 UTC+9
-			// test command 47 // go run main.go 2023/04/09 00:00 UTC+3 UTC+9
-			// test command 48 // go run main.go 2023/04/09 00:00 UTC+4 UTC+9
-			// test command 49 // go run main.go 2023/04/09 00:30:01 UTC UTC+9
-			// test command 50 // go run main.go 2023/04/09 00:00 utc+5 utc+9
-			// test command 51 // go run main.go 2023/04/09 00:00 utc+6 utc+9
-			// test command 52 // go run main.go 2023/04/09 00:00 utc+7 utc+9
-			// test command 53 // go run main.go 2023/04/09 00:00 uTc+8 uTc+9
-			// test command 54 // go run main.go 2023/04/09 00:00 uTc+9 uTc+9
-			// test command 55 // go run main.go 2023/04/09 00:30:01 uTc+10 uTc+9
-			// test command 56 // go run main.go 2023/04/21 12:59:59 UTC-7 UTC+9
-			// test command 57 // go run main.go 2023/04/21 12:59:59 pdt jst
-			// test command 58 // go run main.go 2023/04/21 15:49:42 PDT NZST
+			// test command 48 // go run main.go 2023/04/09 00:00 UTC UTC+9
+			// test command 49 // go run main.go 2023/04/09 00:00 UTC+1 UTC+9
+			// test command 50 // go run main.go 2023/04/09 00:00 UTC+2 UTC+9
+			// test command 51 // go run main.go 2023/04/09 00:00 UTC+3 UTC+9
+			// test command 52 // go run main.go 2023/04/09 00:00 UTC+4 UTC+9
+			// test command 53 // go run main.go 2023/04/09 00:30:01 UTC UTC+9
+			// test command 54 // go run main.go 2023/04/09 00:00 utc+5 utc+9
+			// test command 55 // go run main.go 2023/04/09 00:00 utc+6 utc+9
+			// test command 56 // go run main.go 2023/04/09 00:00 utc+7 utc+9
+			// test command 57 // go run main.go 2023/04/09 00:00 uTc+8 uTc+9
+			// test command 58 // go run main.go 2023/04/09 00:00 uTc+9 uTc+9
+			// test command 59 // go run main.go 2023/04/09 00:30:01 uTc+10 uTc+9
+			// test command 60 // go run main.go 2023/04/21 12:59:59 UTC-7 UTC+9
+			// test command 61 // go run main.go 2023/04/21 12:59:59 pdt jst
+			// test command 62 // go run main.go 2023/04/21 15:49:42 PDT NZST
 
 			year, _ := strconv.Atoi(arg1[0])
 			var m, _ = strconv.Atoi(arg1[1])
@@ -290,21 +297,21 @@ func main() {
 			}
 
 		} else if len(arg2) == 3 {
-			// test command 59 // go run main.go 2023-04-09 00:00 UTC UTC+9
-			// test command 60 // go run main.go 2024-04-09 00:00 UTC+1 UTC+9
-			// test command 61 // go run main.go 2023-04-09 00:00 UTC+2 UTC+9
-			// test command 62 // go run main.go 2023-04-09 00:00 UTC+3 UTC+9
-			// test command 63 // go run main.go 2023-04-09 00:00 UTC+4 UTC+9
-			// test command 64 // go run main.go 2023-04-09 00:30:01 UTC UTC+9
-			// test command 65 // go run main.go 2023-04-09 00:00 utc+5 utc+9
-			// test command 66 // go run main.go 2024-04-09 00:00 utc+6 utc+9
-			// test command 67 // go run main.go 2023-04-09 00:00 utc+7 utc+9
-			// test command 68 // go run main.go 2023-04-09 00:00 uTc+8 uTc+9
-			// test command 69 // go run main.go 2023-04-09 00:00 uTc+9 uTc+9
-			// test command 70 // go run main.go 2023-04-09 00:30:01 uTc+10 uTc+9
-			// test command 71 // go run main.go 2023-04-21 12:59:59 UTC-7 UTC+9
-			// test command 72 // go run main.go 2023-04-21 12:59:59 pdt jst
-			// test command 73 // go run main.go 2023-04-21 15:49:42 PDT NZST
+			// test command 63 // go run main.go 2023-04-09 00:00 UTC UTC+9
+			// test command 64 // go run main.go 2024-04-09 00:00 UTC+1 UTC+9
+			// test command 65 // go run main.go 2023-04-09 00:00 UTC+2 UTC+9
+			// test command 66 // go run main.go 2023-04-09 00:00 UTC+3 UTC+9
+			// test command 67 // go run main.go 2023-04-09 00:00 UTC+4 UTC+9
+			// test command 68 // go run main.go 2023-04-09 00:30:01 UTC UTC+9
+			// test command 69 // go run main.go 2023-04-09 00:00 utc+5 utc+9
+			// test command 70 // go run main.go 2024-04-09 00:00 utc+6 utc+9
+			// test command 71 // go run main.go 2023-04-09 00:00 utc+7 utc+9
+			// test command 72 // go run main.go 2023-04-09 00:00 uTc+8 uTc+9
+			// test command 73 // go run main.go 2023-04-09 00:00 uTc+9 uTc+9
+			// test command 74 // go run main.go 2023-04-09 00:30:01 uTc+10 uTc+9
+			// test command 75 // go run main.go 2023-04-21 12:59:59 UTC-7 UTC+9
+			// test command 76 // go run main.go 2023-04-21 12:59:59 pdt jst
+			// test command 77 // go run main.go 2023-04-21 15:49:42 PDT NZST
 
 			year, _ := strconv.Atoi(arg2[0])
 			var m, _ = strconv.Atoi(arg2[1])


### PR DESCRIPTION
This is a fix not to show any output for invalid abbreviation like NZS as well as invalid offset like UTC-, UTC+ and UTCC. 